### PR TITLE
count_toplevel no longer creates a user-facing .Rd

### DIFF
--- a/R/count.R
+++ b/R/count.R
@@ -47,6 +47,7 @@ create_lockfile <- function() {
 
 #' Determines which of the dependencies are directly
 #' referenced in the user's code
+#' @noRd
 count_toplevel <- function() {
   packrat:::dirDependencies(getwd())
 }


### PR DESCRIPTION
Hides internal documentation for `count_toplevel`. I could not find the roxygen doc for `hello`.

![](https://i.imgur.com/CeLB5um.png)