### PR TITLE
set fallback.ok TRUE

### DIFF
--- a/R/count.R
+++ b/R/count.R
@@ -36,12 +36,13 @@ cleanup <- function(wd, keepLockFile = FALSE) {
 
 create_lockfile <- function() {
   ui("Counting Dependencies ... Hold on, this may take a moment!")
-  suppressMessages({
+  suppressMessages(suppressWarnings({
     packrat:::snapshotImpl(".",
                            snapshot.sources = FALSE,
                            prompt = FALSE,
-                           verbose = FALSE )
-  })
+                           verbose = FALSE,
+                           fallback.ok = TRUE)
+  }))
   ui("Almost done ...")
 }
 


### PR DESCRIPTION
I tried to run `countdeps` on a project where packages were installed from source and I got the following error message:

> Error: Unable to retrieve package records for the following packages:

This PR avoids the error by setting `fallback.ok`.  